### PR TITLE
Add timeout option for xhr requests (default: 5s)

### DIFF
--- a/adapters/xhr.js
+++ b/adapters/xhr.js
@@ -52,6 +52,7 @@ module.exports = function request(options, callback) {
   var requestOpts = merge({}, {
     method: options.method,
     uri: options.url,
+    timeout: options.timeout || 5000,
     headers: merge(defaultHeaders, options.headers || {})
   });
 


### PR DESCRIPTION
Encountered the [xhr package imposed default 5 second timeout](https://github.com/Raynos/xhr/blob/397f7c92782aafe8893d879213904ecb0201f966/index.js#L69) when making grove requests with large result sets, and needed an option to adjust this timeout.
