### PR TITLE
Explicitly set protocol based on URL specified in options

### DIFF
--- a/adapters/node-http.js
+++ b/adapters/node-http.js
@@ -118,6 +118,7 @@ function stream(options) {
     path: destUrl.pathname + (qs ? '?' + qs : ''),
     host: destUrl.host,
     port: destUrl.port,
+    protocol: destUrl.protocol,
     withCredentials: withCredentials
   });
 


### PR DESCRIPTION
For mobile hybrid apps that run from a local file, the request protocol defaults to `file` rather than the protocol that's specified in URL given in the options.